### PR TITLE
Fix typo in WithdrawLP

### DIFF
--- a/src/components/earn/WithdrawLP.tsx
+++ b/src/components/earn/WithdrawLP.tsx
@@ -81,7 +81,7 @@ export default function WithdrawLP({ poolInfo, setHash, setAttempting }: Withdra
       {selectedAmount.greaterThan(JSBI.BigInt('0')) && (
         <div>
           <TYPE.mediumHeader style={{ textAlign: 'center', marginBottom: '0.5rem' }}>
-            You will received
+            You will receive
           </TYPE.mediumHeader>
           {expectedTokens.map((tokenAmount, i) => (
             <>


### PR DESCRIPTION
Noticed there was a small typo in the WithdrawLP component ("You will received" should read "You will receive") so submitting this PR to fix it

<img width="556" alt="Screen Shot 2021-09-29 at 5 13 50 PM" src="https://user-images.githubusercontent.com/10874225/135365438-0b2fb481-4f91-4583-acfc-5556a7c6920e.png">
