### PR TITLE
Kill Poof v1 Pools and Add warnings to all Poof pools

### DIFF
--- a/src/components/Visx/PieChart.tsx
+++ b/src/components/Visx/PieChart.tsx
@@ -36,10 +36,6 @@ export default function DoublePieChart({
   margin = defaultMargin,
   animate = true,
 }: PieProps) {
-  console.log({
-    innerChartData,
-    outerChartData,
-  })
   const outerLabels = outerChartData.map(({ label }) => label)
   const innerLabels = innerChartData.map(({ label }) => label)
   const getOuterColor = scaleOrdinal({

--- a/src/constants/PoolWarnings.json
+++ b/src/constants/PoolWarnings.json
@@ -1,0 +1,6 @@
+{
+  "poof": {
+    "warning": "Depositing to the Poof Private Pools is considered highly risky. We recommend users take the time to understand how pTokens (pUSD, pEUR, pCELO) can be minted/burned and who is eligible to do so. Specifically, we highly encourage LPs to mint their own pTokens instead of buying them on Mobius. Remember that Mobius cannot guarantee the peg of an asset. To learn more, read our article.",
+    "link": "https://medium.com/@mobiusmoney/new-private-pools-on-mobius-making-poof-migration-proof-a5a7a8128cd3"
+  }
+}

--- a/src/constants/StablePools.ts
+++ b/src/constants/StablePools.ts
@@ -3,7 +3,7 @@ import { ChainId, Fraction, JSBI, Token } from '@ubeswap/sdk'
 import { VestType } from 'state/claim/reducer'
 import { WrappedTokenInfo } from 'state/lists/hooks'
 import { MentoConstants } from 'state/mentoPools/reducer'
-import { StableSwapConstants } from 'state/stablePools/reducer'
+import { StableSwapConstants, WarningType } from 'state/stablePools/reducer'
 
 import celoLogo from '../assets/images/celo-chain-logo.png'
 import ethLogo from '../assets/images/ethereum-chain-logo.png'
@@ -109,6 +109,7 @@ export const STATIC_POOL_INFO: { [K in ChainId]: StableSwapConstants[] } = {
   [ChainId.MAINNET]: [
     {
       name: 'Private cUSD V2',
+      warningType: WarningType.POOF,
       tokenAddresses: ['0x765DE816845861e75A25fCA122bb6898B8B1282a', '0xEadf4A7168A82D30Ba0619e64d5BCf5B30B45226'],
       tokens: [
         new WrappedTokenInfo(
@@ -162,6 +163,7 @@ export const STATIC_POOL_INFO: { [K in ChainId]: StableSwapConstants[] } = {
     },
     {
       name: 'Private CELO V2',
+      warningType: WarningType.POOF,
       tokenAddresses: ['0x471EcE3750Da237f93B8E339c536989b8978a438', '0x301a61D01A63c8D670c2B8a43f37d12eF181F997'],
       tokens: [
         new WrappedTokenInfo(
@@ -217,6 +219,7 @@ export const STATIC_POOL_INFO: { [K in ChainId]: StableSwapConstants[] } = {
     },
     {
       name: 'Private cEUR V2',
+      warningType: WarningType.POOF,
       tokenAddresses: ['0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73', '0xD8761DD6c7cB54febD33adD699F5E4440b62E01B'],
       tokens: [
         new WrappedTokenInfo(
@@ -642,6 +645,7 @@ export const STATIC_POOL_INFO: { [K in ChainId]: StableSwapConstants[] } = {
     },
     {
       name: 'Private cUSD V1',
+      warningType: WarningType.POOF,
       tokenAddresses: ['0x765DE816845861e75A25fCA122bb6898B8B1282a', '0xB4aa2986622249B1F45eb93F28Cfca2b2606d809'],
       tokens: [
         new WrappedTokenInfo(
@@ -692,6 +696,7 @@ export const STATIC_POOL_INFO: { [K in ChainId]: StableSwapConstants[] } = {
       additionalRewardRate: ['0', '0'],
       displayChain: Chain.Celo,
       coin: Coins.USD,
+      isKilled: true,
     },
     {
       name: 'asUSDC (AllBridge)',
@@ -1010,6 +1015,7 @@ export const STATIC_POOL_INFO: { [K in ChainId]: StableSwapConstants[] } = {
     },
     {
       name: 'Private CELO V1',
+      warningType: WarningType.POOF,
       tokenAddresses: ['0x471EcE3750Da237f93B8E339c536989b8978a438', '0xE74AbF23E1Fdf7ACbec2F3a30a772eF77f1601E1'],
       tokens: [
         new WrappedTokenInfo(
@@ -1062,9 +1068,11 @@ export const STATIC_POOL_INFO: { [K in ChainId]: StableSwapConstants[] } = {
       // additionalRewardRate: ['730282730000000'],
       displayChain: Chain.Celo,
       coin: Coins.Celo,
+      isKilled: true,
     },
     {
       name: 'Private cEUR V1',
+      warningType: WarningType.POOF,
       tokenAddresses: ['0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73', '0x56072D4832642dB29225dA12d6Fd1290E4744682'],
       tokens: [
         new WrappedTokenInfo(
@@ -1117,9 +1125,11 @@ export const STATIC_POOL_INFO: { [K in ChainId]: StableSwapConstants[] } = {
       // additionalRewardRate: ['730282730000000'],
       displayChain: Chain.Celo,
       coin: Coins.Eur,
+      isKilled: true,
     },
     {
       name: 'Private cUSD V1 [DISABLED]',
+      warningType: WarningType.POOF,
       tokenAddresses: ['0xB4aa2986622249B1F45eb93F28Cfca2b2606d809'],
       tokens: [
         new WrappedTokenInfo(

--- a/src/hooks/useSwapCallback.ts
+++ b/src/hooks/useSwapCallback.ts
@@ -64,10 +64,6 @@ function useSwapCallArguments(
     const { indexFrom = 0, indexTo = 0 } = trade || {}
     const outputRaw = trade.output.raw
     const minDy = JSBI.subtract(outputRaw, JSBI.divide(outputRaw, JSBI.divide(BIPS_BASE, JSBI.BigInt(allowedSlippage))))
-
-    console.log(indexFrom.toString())
-    console.log(indexTo.toString())
-
     const swapCallParameters: SwapParameters = {
       methodName: trade.isMeta ? 'swapUnderlying' : 'swap',
       args: [

--- a/src/pages/ApeViewer/index.tsx
+++ b/src/pages/ApeViewer/index.tsx
@@ -214,7 +214,6 @@ export default function ApeViewer() {
     })
   }
   const baseUrl = 'https://ipfs.io/ipfs/bafybeiasnbk7bztvmytiqf2a5aw5jmivvnxhrdwtp72ihbpjrlh33g32ee/apes/'
-  console.log(apeIDs)
   return (
     <Container>
       <div style={{ width: '100%', display: 'flex', justifyContent: 'center' }}>

--- a/src/pages/OpenSum/index.tsx
+++ b/src/pages/OpenSum/index.tsx
@@ -170,7 +170,6 @@ export default function OpenSum() {
   )
 
   const handleMaxInput = useCallback(() => {
-    console.log(maxAmountInput?.toExact())
     maxAmountInput && setInputValue(maxAmountInput.toExact())
   }, [maxAmountInput, setInputValue])
 

--- a/src/state/stablePools/hooks.ts
+++ b/src/state/stablePools/hooks.ts
@@ -10,9 +10,10 @@ import { useDefaultTokenList } from 'state/lists/hooks'
 import { useSingleContractMultipleData } from 'state/multicall/hooks'
 import { tryParseAmount } from 'state/swap/hooks'
 
+import WARNINGS from '../../constants/PoolWarnings.json'
 import { StableSwapMath } from '../../utils/stableSwapMath'
 import { AppState } from '..'
-import { StableSwapPool } from './reducer'
+import { StableSwapPool, WarningType } from './reducer'
 import { BigIntToJSBI } from './updater'
 
 export interface StablePoolInfo {
@@ -246,4 +247,12 @@ export function useExternalRewards({ poolName }: { poolName: string }): TokenAmo
       )
   )
   return externalRewards
+}
+
+export function useWarning(pool: string | undefined): { warning: string; link?: string } | undefined {
+  const warningType = useSelector<AppState, WarningType | undefined>(
+    (state) => state.stablePools.pools[pool ?? '']?.pool?.warningType ?? undefined
+  )
+  if (!warningType) return undefined
+  return WARNINGS[warningType] as any as { warning: string; link?: string }
 }

--- a/src/state/stablePools/reducer.ts
+++ b/src/state/stablePools/reducer.ts
@@ -6,6 +6,10 @@ import { StableSwapMath } from 'utils/stableSwapMath'
 
 import { initPool, updateExternalRewards, updateVariableData } from './actions'
 
+export enum WarningType {
+  POOF = 'poof',
+}
+
 export type StableStakingInfo = {
   userStaked: JSBI
   totalStakedAmount: JSBI
@@ -68,6 +72,7 @@ export type StableSwapConstants = StableSwapMathConstants & {
   coin: Coins
   disabled?: boolean
   isKilled?: boolean
+  warningType?: WarningType
 }
 
 export type StableSwapPool = StableSwapConstants & StableSwapVariable

--- a/src/state/staking/updater.ts
+++ b/src/state/staking/updater.ts
@@ -29,9 +29,6 @@ export default function StakingUpdater() {
   const totalWeight = useSingleCallResult(controller, 'get_total_weight')
   const snxRewardRate = useSingleCallResult(snxContract, 'rewardRate()')
   const snxToClaim = useSingleCallResult(snxContract, 'earned(address)', [account ?? undefined])
-  console.log(`address: ${snxAddress}`)
-  console.log('To claim: ', snxToClaim)
-  console.log('Reward rate: ', snxRewardRate)
   dispatch(
     updateSNX({
       rewardRate: snxRewardRate?.result ? JSBI.BigInt(snxRewardRate?.result?.[0] ?? '0') : undefined,


### PR DESCRIPTION
This PR creates the notion of warnings for specific pool types.

A WarningType can apply to multiple pools.  The corresponding warning, and link to more information is defined in the Warning.json under the constants folder.  When a user goes to deposit, they will first see the warning and then have to acknowledge said warning before continuing to deposit.

Additional work can add a cookie to a specific warning so that a user can opt to not be shown the same warning multiple times.

This PR also sets the old V1 pools as killed in the UI.  Poof V1 pools were killed at the following txns: 

pUSD - txn 0x9dbba9b50c2230ce3a0abb86381624b118c9b144341250520fb3e084b43c6e5a
pEUR - txn 0x5c12e9f69e5f412d4de8a1b51ac7c8345db27206bf96636f00818865727a0b47
pCELO - txn 0xdea78275a63c4df695a7a9d8c1ec97504b23c7c3f7647148310657e42fdcaa1b 
