### PR TITLE
Move deprecated pools to a separate section

### DIFF
--- a/src/components/earn/StablePoolCard.tsx
+++ b/src/components/earn/StablePoolCard.tsx
@@ -25,21 +25,6 @@ import { Row, RowBetween, RowFixed } from '../Row'
 import DepositModal from './DepositModal'
 import WithdrawModal from './WithdrawModal'
 
-const SubHeader = styled.div`
-  display: flex;
-  justify-content: space-between;
-  padding: 1rem;
-  padding-top: 0;
-`
-
-const Divider = styled.div`
-  width: 100%;
-  height: 1px;
-  margin-top: 0.5rem;
-  margin-bottom: 1rem;
-  background: ${({ theme }) => theme.bg4};
-`
-
 const StyledButton = styled(ButtonPrimary)<{ background: any; backgroundHover: any; eth: boolean }>`
   background: ${({ background }) => background};
   flex: 0.6;
@@ -311,22 +296,6 @@ export const StablePoolCard: React.FC<Props> = ({ poolInfo }: Props) => {
       {openWithdraw && (
         <WithdrawModal isOpen={openWithdraw} onDismiss={() => setOpenWithdraw(false)} poolInfo={poolInfo} />
       )}
-      <TopSection>
-        {poolInfo.isKilled && (
-          <RowFixed>
-            <TYPE.red fontSize={[18, 26]}>[KILLED]</TYPE.red>
-            <QuestionHelper
-              text={
-                <>
-                  The gauge for this pool has been killed.
-                  <br />
-                  It will no longer produce any mobi rewards.
-                </>
-              }
-            />
-          </RowFixed>
-        )}
-      </TopSection>
       <TopSection>
         <RowFixed style={{ gap: '10px' }}>
           <TYPE.black fontWeight={600} fontSize={[18, 24]}>

--- a/src/constants/StablePools.ts
+++ b/src/constants/StablePools.ts
@@ -1180,6 +1180,7 @@ export const STATIC_POOL_INFO: { [K in ChainId]: StableSwapConstants[] } = {
       displayChain: Chain.Celo,
       coin: Coins.USD,
       disabled: true,
+      isKilled: true,
     },
   ],
   [ChainId.ALFAJORES]: [

--- a/src/pages/Pool/index.tsx
+++ b/src/pages/Pool/index.tsx
@@ -185,7 +185,7 @@ export default function Pool() {
               {showDeprecated ? 'Hide deprecated pools' : 'Show deprecated pools'}
             </TYPE.largeHeader>
             <QuestionHelper
-              text={<>The gauges for these pools have been killed and will no longer produce any mobi rewards</>}
+              text={<>Users are encouraged to withdraw from these pools as they have been replaced with new ones. The gauges for these pools have been killed and will no longer produce any mobi rewards</>}
             />
           </RowFixed>
         </AutoColumn>

--- a/src/pages/Pool/index.tsx
+++ b/src/pages/Pool/index.tsx
@@ -82,6 +82,7 @@ export default function Pool() {
   const stablePools = useStablePoolInfo()
 
   const [selection, setSelection] = React.useState<Chain>(Chain.All)
+  const [showDeprecated, setShowDeprecated] = React.useState(false)
 
   const tvl = stablePools.reduce((accum, poolInfo) => {
     const price =
@@ -106,6 +107,10 @@ export default function Pool() {
     if (isStaking1 && !isStaking2) return false
     return true
   }
+
+  const sortedFilterdPools = stablePools
+    ?.sort(sortCallback)
+    .filter((pool) => selection === Chain.All || selection === pool.displayChain)
 
   return (
     <PageWrapper gap="lg" justify="center" style={{ marginTop: isMobile ? '-1rem' : '3rem' }}>
@@ -160,15 +165,32 @@ export default function Pool() {
           {stablePools && stablePools?.length === 0 ? (
             <Loader style={{ margin: 'auto' }} />
           ) : (
-            stablePools
-              ?.sort(sortCallback)
-              .filter((pool) => selection === Chain.All || selection === pool.displayChain)
+            sortedFilterdPools
+              .filter((pool) => !pool.isKilled && !pool.disabled)
               .map((pool) => (
                 <ErrorBoundary key={pool.poolAddress || '000'}>
                   <StablePoolCard poolInfo={pool} />
                 </ErrorBoundary>
               ))
           )}
+        </PoolSection>
+        <AutoColumn gap="lg" style={{ width: '100%', maxWidth: '720px', justifyContent: 'center' }}>
+          <TYPE.largeHeader
+            style={{ textDecoration: 'underline', cursor: 'pointer' }}
+            onClick={() => setShowDeprecated(!showDeprecated)}
+          >
+            {showDeprecated ? 'Hide deprecated pools' : 'Show deprecated pools'}
+          </TYPE.largeHeader>
+        </AutoColumn>
+        <PoolSection>
+          {showDeprecated &&
+            sortedFilterdPools
+              .filter((pool) => pool.isKilled || pool.disabled)
+              .map((pool) => (
+                <ErrorBoundary key={pool.poolAddress || '000'}>
+                  <StablePoolCard poolInfo={pool} />
+                </ErrorBoundary>
+              ))}
         </PoolSection>
       </AutoColumn>
     </PageWrapper>

--- a/src/pages/Pool/index.tsx
+++ b/src/pages/Pool/index.tsx
@@ -1,5 +1,7 @@
 import { ErrorBoundary } from '@sentry/react'
 import { cUSD, JSBI, TokenAmount } from '@ubeswap/sdk'
+import QuestionHelper from 'components/QuestionHelper'
+import { RowFixed } from 'components/Row'
 import { Chain, Coins, PRICE } from 'constants/StablePools'
 import { useActiveContractKit } from 'hooks'
 import { useMobi } from 'hooks/Tokens'
@@ -175,12 +177,17 @@ export default function Pool() {
           )}
         </PoolSection>
         <AutoColumn gap="lg" style={{ width: '100%', maxWidth: '720px', justifyContent: 'center' }}>
-          <TYPE.largeHeader
-            style={{ textDecoration: 'underline', cursor: 'pointer' }}
-            onClick={() => setShowDeprecated(!showDeprecated)}
-          >
-            {showDeprecated ? 'Hide deprecated pools' : 'Show deprecated pools'}
-          </TYPE.largeHeader>
+          <RowFixed>
+            <TYPE.largeHeader
+              style={{ textDecoration: 'underline', cursor: 'pointer' }}
+              onClick={() => setShowDeprecated(!showDeprecated)}
+            >
+              {showDeprecated ? 'Hide deprecated pools' : 'Show deprecated pools'}
+            </TYPE.largeHeader>
+            <QuestionHelper
+              text={<>The gauge for these pools have been killed and will no longer produce any mobi rewards</>}
+            />
+          </RowFixed>
         </AutoColumn>
         <PoolSection>
           {showDeprecated &&

--- a/src/pages/Pool/index.tsx
+++ b/src/pages/Pool/index.tsx
@@ -185,7 +185,7 @@ export default function Pool() {
               {showDeprecated ? 'Hide deprecated pools' : 'Show deprecated pools'}
             </TYPE.largeHeader>
             <QuestionHelper
-              text={<>The gauge for these pools have been killed and will no longer produce any mobi rewards</>}
+              text={<>The gauges for these pools have been killed and will no longer produce any mobi rewards</>}
             />
           </RowFixed>
         </AutoColumn>


### PR DESCRIPTION
Moves the deprecated pools to a new section of the pools page that is hidden as a default. Can be revealed by click the button. Also remove the killed tag from the killed pools because they are all under the same section.