### PR TITLE
Hotfix 01 - Poof pool equal deposits, weekly volume, total volume

### DIFF
--- a/src/components/earn/DepositModal.tsx
+++ b/src/components/earn/DepositModal.tsx
@@ -51,7 +51,8 @@ export default function DepositModal({ isOpen, onDismiss, poolInfo }: DepositMod
   const [input, setInput] = useState<(string | undefined)[]>(new Array(tokens.length).fill(undefined))
   const [warningAcknowledged, setWarningAcknowledged] = useState<boolean>(!warning)
   const isFirstDeposit = totalDeposited.equalTo('0')
-  const [useEqualAmount, setUseEqualAmount] = useState<boolean>(isFirstDeposit)
+  const forceEqualDeposit = isFirstDeposit || warning?.modification === 'require-equal-deposit'
+  const [useEqualAmount, setUseEqualAmount] = useState<boolean>(forceEqualDeposit)
   const deadline = useTransactionDeadline()
 
   const sumAmount = tokens
@@ -148,11 +149,10 @@ export default function DepositModal({ isOpen, onDismiss, poolInfo }: DepositMod
                 <TYPE.largeHeader>Deposit to {poolInfo.name}</TYPE.largeHeader>
                 <CloseIcon onClick={wrappedOndismiss} />
               </RowBetween>
-              {isFirstDeposit && (
+              {forceEqualDeposit && (
                 <AutoRow>
                   <TYPE.body color="red">
-                    You are the first to deposit into the pool! <br />
-                    Because of this, you will need to deposit an equal amount of tokens.
+                    Due to the current conditions of this pool, deposits must be made in equal amounts of both tokens.
                   </TYPE.body>
                 </AutoRow>
               )}
@@ -166,7 +166,7 @@ export default function DepositModal({ isOpen, onDismiss, poolInfo }: DepositMod
                 <Toggle
                   id="toggle-equal-amount-button"
                   isActive={useEqualAmount}
-                  toggle={() => !isFirstDeposit && setUseEqualAmount(!useEqualAmount)}
+                  toggle={() => !forceEqualDeposit && setUseEqualAmount(!useEqualAmount)}
                 />
               </RowBetween>
               {poolInfo.tokens.map((token, i) => (

--- a/src/components/earn/StablePoolCard.tsx
+++ b/src/components/earn/StablePoolCard.tsx
@@ -411,6 +411,19 @@ export const StablePoolCard: React.FC<Props> = ({ poolInfo }: Props) => {
 
               {openManage && (
                 <>
+                  <RowBetween>
+                    <TYPE.darkGray>Total volume</TYPE.darkGray>
+                    <RowFixed>
+                      <TYPE.black fontWeight={800}>
+                        {poolInfo.totalVolume
+                          ? `${!pegComesAfter ? peggedTo : ''}${totalDisplay(poolInfo.totalVolume)} ${
+                              pegComesAfter ? peggedTo : ''
+                            }`
+                          : '-'}
+                      </TYPE.black>
+                    </RowFixed>
+                  </RowBetween>
+
                   {mobiRate && (
                     <RowBetween>
                       <TYPE.darkGray>MOBI rate</TYPE.darkGray>

--- a/src/constants/PoolWarnings.json
+++ b/src/constants/PoolWarnings.json
@@ -1,6 +1,7 @@
 {
   "poof": {
     "warning": "Depositing to the Poof Private Pools is considered highly risky. We recommend users take the time to understand how pTokens (pUSD, pEUR, pCELO) can be minted/burned and who is eligible to do so. Specifically, we highly encourage LPs to mint their own pTokens instead of buying them on Mobius. Remember that Mobius cannot guarantee the peg of an asset. To learn more, read our article.",
-    "link": "https://medium.com/@mobiusmoney/new-private-pools-on-mobius-making-poof-migration-proof-a5a7a8128cd3"
+    "link": "https://medium.com/@mobiusmoney/new-private-pools-on-mobius-making-poof-migration-proof-a5a7a8128cd3",
+    "modification": "require-equal-deposit"
   }
 }

--- a/src/state/stablePools/hooks.ts
+++ b/src/state/stablePools/hooks.ts
@@ -17,6 +17,8 @@ import { AppState } from '..'
 import { StableSwapConstants, StableSwapPool, WarningType } from './reducer'
 import { BigIntToJSBI } from './updater'
 
+export type WarningModifications = 'require-equal-deposit' | 'none'
+
 export interface StablePoolInfo {
   readonly name: string
   readonly poolAddress?: string
@@ -273,10 +275,12 @@ export function useExternalRewards({ address }: { address: string }): TokenAmoun
   return externalRewards
 }
 
-export function useWarning(pool: string | undefined): { warning: string; link?: string } | undefined {
+export function useWarning(
+  pool: string | undefined
+): { warning: string; link?: string; modification?: WarningModifications } | undefined {
   const warningType = useSelector<AppState, WarningType | undefined>(
     (state) => state.stablePools.pools[pool?.toLowerCase() ?? '']?.pool?.warningType ?? undefined
   )
   if (!warningType) return undefined
-  return WARNINGS[warningType] as any as { warning: string; link?: string }
+  return WARNINGS[warningType] as any as { warning: string; link?: string; modification?: WarningModifications }
 }

--- a/src/state/stablePools/hooks.ts
+++ b/src/state/stablePools/hooks.ts
@@ -137,6 +137,7 @@ export const getPoolInfo = (
         isDisabled: pool.disabled,
         isKilled: pool.isKilled,
         weeklyVolume: tryParseAmount(pool.volume.week.toFixed(6), pool.lpToken) ?? new TokenAmount(pool.lpToken, '0'),
+        totalVolume: tryParseAmount(pool.volume.total?.toFixed(6), pool.lpToken) ?? new TokenAmount(pool.lpToken, '0'),
         poolLoading: pool.loadingPool,
         gaugeLoading: pool.loadingGauge,
       }

--- a/src/state/stablePools/reducer.ts
+++ b/src/state/stablePools/reducer.ts
@@ -20,6 +20,7 @@ export type ExternalRewards = {
 export type PoolOnlyInfo = {
   id: string
   volume: {
+    total: number
     day: number
     week: number
   }

--- a/src/state/stablePools/updater.ts
+++ b/src/state/stablePools/updater.ts
@@ -50,13 +50,10 @@ export function UpdateVariablePoolInfo(): null {
         A
         balances
         virtualPrice
-        hourlyVolumes(first: 2) {
+        dailyVolumes(first: 2, orderBy: timestamp, orderDirection: desc) {
           volume
         }
-        dailyVolumes(first: 2) {
-          volume
-        }
-        weeklyVolumes(first: 2) {
+        weeklyVolumes(first: 2, orderBy: timestamp, orderDirection: desc) {
           volume
         }
       }
@@ -91,7 +88,7 @@ export function UpdateVariablePoolInfo(): null {
         id: pool.id,
         volume: {
           day: parseFloat(pool.dailyVolumes[0]?.volume ?? '0'),
-          week: parseFloat(pool.weeklyVolumes[1]?.volume ?? '0'),
+          week: parseFloat(pool.weeklyVolumes[0]?.volume ?? '0'),
         },
         balances: lpInfo[pool.id].balances ?? pool?.balances?.map((b: string) => JSBI.BigInt(b)),
         amp: JSBI.BigInt(pool.A),

--- a/src/state/stablePools/updater.ts
+++ b/src/state/stablePools/updater.ts
@@ -50,7 +50,7 @@ export function UpdateVariablePoolInfo(): null {
         A
         balances
         virtualPrice
-        dailyVolumes(first: 2, orderBy: timestamp, orderDirection: desc) {
+        dailyVolumes(orderBy: timestamp, orderDirection: desc) {
           volume
         }
         weeklyVolumes(first: 2, orderBy: timestamp, orderDirection: desc) {
@@ -87,6 +87,7 @@ export function UpdateVariablePoolInfo(): null {
       .map((pool) => ({
         id: pool.id,
         volume: {
+          total: pool.dailyVolumes.reduce((accum: number, el: string) => accum + parseFloat(el.volume), 0),
           day: parseFloat(pool.dailyVolumes[0]?.volume ?? '0'),
           week: parseFloat(pool.weeklyVolumes[0]?.volume ?? '0'),
         },


### PR DESCRIPTION
This PR does the following:
- Requires equal-sided deposits for poof pools.  This is being enforced to avoid a situation like poof v1 pools, where users entered without any debt position and the peg was lost.  It is still possible for a user to enter the pool without a debt position, by first swapping to p* assets and then adding liquidity at equal amounts, but this action is highly discouraged.
- Fixes the weekly volume displayed on pool cards.  Previously, the weekly volume displayed was that of the volume for the 2nd week of the pool's existence.  Now, we sort the returned volume by descending timestamp and take the 0th index.
- Adds the "Total Volume" metric to pool cards, which is only shown when a user expands a card.