### PR TITLE
Hotfix 02 - Contract Balances & Price Impact

### DIFF
--- a/src/components/swap/routing/TradeDetails/MobiusTradeDetails.tsx
+++ b/src/components/swap/routing/TradeDetails/MobiusTradeDetails.tsx
@@ -52,7 +52,7 @@ export const MobiusTradeDetails: React.FC<Props> = ({ trade, allowedSlippage, me
           </TYPE.black>
           <QuestionHelper text="The difference between the market price and estimated price due to trade size." />
         </RowFixed>
-        <FormattedPriceImpact priceImpact={priceImpactWithoutFee} />
+        <FormattedPriceImpact priceImpact={trade.priceImpact} />
       </RowBetween>
 
       <RowBetween>

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -276,16 +276,22 @@ export default function Swap() {
             <Card padding={'0px'} borderRadius={'8px'}>
               <AutoColumn gap="8px" style={{ padding: '0 8px' }}>
                 {Boolean(trade) && (
-                  <RowBetween align="center">
-                    <Text fontWeight={500} fontSize={14} color={theme.text2}>
-                      Price
-                    </Text>
-                    <TradePrice
-                      price={trade?.executionPrice}
-                      showInverted={showInverted}
-                      setShowInverted={setShowInverted}
-                    />
-                  </RowBetween>
+                  <>
+                    <RowBetween align="center">
+                      <Text fontWeight={500} fontSize={14} color={theme.text2}>
+                        Price
+                      </Text>
+                      <TradePrice
+                        price={trade?.executionPrice}
+                        showInverted={showInverted}
+                        setShowInverted={setShowInverted}
+                      />
+                    </RowBetween>
+                    <RowBetween>
+                      <TYPE.body>Price Impact</TYPE.body>
+                      <TYPE.body>{`${trade?.priceImpact.toFixed(4)}%`}</TYPE.body>
+                    </RowBetween>
+                  </>
                 )}
                 {allowedSlippage !== INITIAL_ALLOWED_SLIPPAGE && (
                   <RowBetween align="center">

--- a/src/pages/Vote/VotePage.tsx
+++ b/src/pages/Vote/VotePage.tsx
@@ -133,7 +133,6 @@ export default function VotePage({
   // modal for casting votes
   const showVoteModal = useModalOpen(ApplicationModal.VOTE)
   const toggleVoteModal = useToggleVoteModal()
-  console.log(proposalData)
 
   // get and format date from data
   const currentTimestamp = useCurrentBlockTimestamp()

--- a/src/state/governance/hooks.ts
+++ b/src/state/governance/hooks.ts
@@ -223,7 +223,6 @@ export function useUserVotesAsOfBlock(block: number | undefined): TokenAmount | 
 
   // check for available votes
   const veMOBI = chainId ? VEMOBI[chainId] : undefined
-  console.log(account, block)
   const votes = useSingleCallResult(veMOBIContract, 'balanceOfAt(address, uint256)', [
     account ?? undefined,
     block ?? undefined,

--- a/src/state/stablePools/hooks.ts
+++ b/src/state/stablePools/hooks.ts
@@ -60,7 +60,6 @@ export function useCurrentPool(tok1: string, tok2: string): readonly [StableSwap
     Object.values(state.stablePools.pools).map(({ pool }) => {
       if (!pool.metaPool || pool.disabled) return pool
       const underlying = state.stablePools.pools[pool.metaPool]?.pool
-      console.log(pool)
       return {
         ...pool,
         tokenAddresses: pool.tokenAddresses.concat(underlying.tokenAddresses),

--- a/src/state/stablePools/hooks.ts
+++ b/src/state/stablePools/hooks.ts
@@ -117,7 +117,7 @@ export const getPoolInfo = (
           )
         ),
         workingSupply: pool.workingLiquidity,
-        balances: pool.tokens.map((token, i) => new TokenAmount(token, pool.balances[i] ?? '0')),
+        balances: pool.tokens.map((token, i) => new TokenAmount(token, pool.approxBalances[i] ?? '0')),
         pegComesAfter: pool.pegComesAfter,
         mobiRate: pool.isKilled ? JSBI.BigInt('0') : pool.totalMobiRate,
         pendingMobi: pool.pendingMobi,

--- a/src/state/stablePools/reducer.ts
+++ b/src/state/stablePools/reducer.ts
@@ -24,6 +24,7 @@ export type PoolOnlyInfo = {
     day: number
     week: number
   }
+  approxBalances: JSBI[]
   balances: JSBI[]
   amp: JSBI
   virtualPrice: JSBI
@@ -149,7 +150,7 @@ export default createReducer<PoolState>(initialState, (builder) =>
       const copiedState = current(state)
       info.forEach((pool) => {
         const cur = copiedState.pools[pool.id].pool as any as StableSwapPool
-        const newPool = { ...cur, ...pool, loadingPool: false }
+        const newPool = { ...cur, ...pool }
 
         const math = new StableSwapMath(newPool)
         state.pools[pool.id] = {

--- a/src/state/stablePools/updater.ts
+++ b/src/state/stablePools/updater.ts
@@ -73,9 +73,9 @@ export function UpdateVariablePoolInfo(): null {
         poolAddresses[i],
       ])
       .reduce(
-        (accum, [total, user, virtualPrice, balance, address]) => ({
+        (accum, [total, user, virtualPrice, balances, address]) => ({
           ...accum,
-          [(address as any as string).toLowerCase()]: { total, user, balance, virtualPrice },
+          [(address as any as string).toLowerCase()]: { total, user, balances, virtualPrice },
         }),
         {}
       )
@@ -91,12 +91,14 @@ export function UpdateVariablePoolInfo(): null {
           day: parseFloat(pool.dailyVolumes[0]?.volume ?? '0'),
           week: parseFloat(pool.weeklyVolumes[0]?.volume ?? '0'),
         },
-        balances: lpInfo[pool.id].balances ?? pool?.balances?.map((b: string) => JSBI.BigInt(b)),
+        approxBalances: pool?.balances?.map((b: string) => JSBI.BigInt(b)),
+        balances: lpInfo[pool.id].total ? lpInfo[pool.id].balances : undefined,
         amp: JSBI.BigInt(pool.A),
         aPrecise: JSBI.BigInt(parseInt(pool.A) * 100),
         virtualPrice: lpInfo[pool.id].virtualPrice,
         lpTotalSupply: lpInfo[pool.id].total,
         lpOwned: lpInfo[pool.id].user,
+        loadingPool: !lpInfo[pool.id].total,
       }))
     dispatch(updatePools({ info: poolInfo }))
     return null

--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -317,10 +317,8 @@ function calcInputOutput(
         const lpIndexFrom = poolInfo.tokenAddresses.indexOf(underlyingPool?.lpToken.address)
 
         const metaexpectedOut = underlyingMath.calculateTokenAmount(lpInput, true)
-        console.log('metaExtectedOut', metaexpectedOut.toString())
         details[0] = parsedAmount
         const [expectedOut, fee] = math.calculateSwap(lpIndexFrom, indexTo, metaexpectedOut, math.calc_xp())
-        console.log('expected', expectedOut.toString())
         details[1] = new TokenAmount(output, expectedOut)
         details[2] = new TokenAmount(input, fee)
       } else {
@@ -339,9 +337,7 @@ function calcInputOutput(
         const [metaExpectedOut, metaFee] = math.calculateSwap(indexFrom, lpIndexTo, parsedAmount.raw, math.calc_xp())
 
         const metaIndexOut = underTokens.map(({ address }) => address).indexOf(output.address)
-        console.log('djfdia', metaExpectedOut.toString())
         const [expectedOut, fee] = underlyingMath.calculateWithdrawOneToken(metaIndexOut, metaExpectedOut)
-        console.log(expectedOut.toString(), 'expreccc')
         details[0] = parsedAmount
         details[1] = new TokenAmount(output, expectedOut)
         details[2] = new TokenAmount(

--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -439,8 +439,7 @@ export function useMobiusTradeInfo(): {
   if (!parsedAmount) {
     inputError = inputError ?? 'Enter an amount'
   }
-
-  if (!pool) {
+  if (!pool || pool.loadingPool) {
     inputError = inputError ?? 'Pool Info Loading'
   }
 

--- a/src/utils/stableSwapMath.ts
+++ b/src/utils/stableSwapMath.ts
@@ -220,10 +220,8 @@ export class StableSwapMath {
   }
 
   calculateSwap(indexFrom: number, indexTo: number, dx: JSBI, xp: JSBI[]): [JSBI, JSBI] {
-    console.log({ indexFrom, dx })
     const x = JSBI.add(xp[indexFrom], JSBI.multiply(this.tokenPrecisionMultipliers[indexFrom], dx))
     const y = this.getY(indexFrom, indexTo, x, xp)
-    console.log({ xp, indexTo, y, ONE })
     let dy = JSBI.subtract(JSBI.subtract(xp[indexTo], y), ONE)
     const dyFee = JSBI.divide(JSBI.multiply(dy, this.swapFee), this.FEE_DENOMINATOR)
     dy = JSBI.divide(JSBI.subtract(dy, dyFee), this.tokenPrecisionMultipliers[indexTo])
@@ -255,7 +253,6 @@ export class StableSwapMath {
     const newY = this.getYD(preciseA, index, xp, d1)
     const xpReduced: JSBI[] = new Array(xp.length).fill(JSBI.BigInt('0'))
     const feePerToken = this._feePerToken(this.swapFee, JSBI.BigInt(xp.length))
-    console.log(feePerToken.toString(), this.FEE_DENOMINATOR.toString())
     for (let i = 0; i < xp.length; i++) {
       const xpi = xp[i]
       const toSubtract =


### PR DESCRIPTION
This PR does the following:

- Makes the swap page use token balances queried directly from the contracts rather than the subgraph.  The subgraph tends to lag behind sometimes, so price quotes were not always accurate.  The pool page still uses the subgraph balances because its much faster, and an approximation here is fine
- Calculates price impact for a trade based off a trade of one single token.  This price impact is now displayed beneath price on the swap modal.
- Removes unnecessary logs to the console when calculating swaps

![Screen Shot 2022-01-11 at 10 38 32 AM](https://user-images.githubusercontent.com/49253708/149001965-d31d9fff-dcd7-4bdb-a37b-8fe6ab185cee.png)
