### PR TITLE
Swap component styling

### DIFF
--- a/src/components/CurrencyInputPanel/index.tsx
+++ b/src/components/CurrencyInputPanel/index.tsx
@@ -14,7 +14,6 @@ import { TYPE } from '../../theme'
 import CurrencyLogo from '../CurrencyLogo'
 import DoubleCurrencyLogo from '../DoubleLogo'
 import { Input as NumericalInput } from '../NumericalInput'
-import { RowBetween } from '../Row'
 import CurrencySearchModal from '../SearchModal/CurrencySearchModal'
 
 // const ColorShift = keyframes`
@@ -55,7 +54,7 @@ const InputRow = styled.div<{ selected: boolean }>`
   ${({ theme }) => theme.flexRowNoWrap};
   align-items: center;
   justify-content: space-between;
-  padding: ${({ selected }) => (selected ? '0.75rem 1rem 1.5rem .75rem' : '0.75rem 1rem 1.5rem .75rem')};
+  padding: ${({ selected }) => (selected ? '0.75rem 1rem 0rem .75rem' : '0.75rem 1rem 0rem .75rem')};
 `
 
 const InputDiv = styled.div`
@@ -99,11 +98,12 @@ const CurrencySelect = styled.button<{
 
 const LabelRow = styled.div`
   ${({ theme }) => theme.flexRowNoWrap}
-  align-items: center;
+  align-items: right;
+  justify-content: right;
   color: ${({ theme }) => theme.text1};
   font-size: 0.75rem;
   line-height: 1rem;
-  padding: 0.75rem 1rem 0 1rem;
+  padding: 0.75rem 1rem 0.75rem 1rem;
   background-color: ${({ theme }) => theme.bg2}
   span:hover {
     cursor: pointer;
@@ -240,28 +240,6 @@ export default function CurrencyInputPanel({
   return (
     <InputPanel id={id} hideInput={false} {...rest}>
       <Container hideInput={hideInput}>
-        {!hideInput && (
-          <LabelRow>
-            <RowBetween>
-              <TYPE.body color={theme.text2} fontWeight={500} fontSize={14}>
-                {label}
-              </TYPE.body>
-              {account && (
-                <TYPE.body
-                  onClick={onMax}
-                  color={theme.text2}
-                  fontWeight={500}
-                  fontSize={14}
-                  style={{ display: 'inline', cursor: 'pointer' }}
-                >
-                  {!hideBalance && !!currency && selectedCurrencyBalance
-                    ? (customBalanceText ?? 'Balance: ') + selectedCurrencyBalance?.toSignificant(6)
-                    : ' -'}
-                </TYPE.body>
-              )}
-            </RowBetween>
-          </LabelRow>
-        )}
         <InputRow style={hideInput ? { padding: '0', borderRadius: '8px' } : {}} selected={disableCurrencySelect}>
           {/* <div style={{ display: 'flex', alignItems: 'center' }}> */}
           <CurrencySelect
@@ -315,6 +293,24 @@ export default function CurrencyInputPanel({
             </InputDiv>
           )}
         </InputRow>
+        {!hideInput && (
+          <LabelRow>
+            {account && (
+              <TYPE.body
+                onClick={onMax}
+                color={theme.text2}
+                fontWeight={500}
+                fontSize={14}
+                style={{ display: 'inline', cursor: 'pointer' }}
+              >
+                {!hideBalance &&
+                  !!currency &&
+                  selectedCurrencyBalance &&
+                  (customBalanceText ?? 'Balance: ') + selectedCurrencyBalance?.toSignificant(6)}
+              </TYPE.body>
+            )}
+          </LabelRow>
+        )}
       </Container>
       {!disableCurrencySelect && onCurrencySelect && (
         <CurrencySearchModal

--- a/src/components/CurrencyInputPanel/index.tsx
+++ b/src/components/CurrencyInputPanel/index.tsx
@@ -293,7 +293,7 @@ export default function CurrencyInputPanel({
                     ? currency.symbol.slice(0, 4) +
                       '...' +
                       currency.symbol.slice(currency.symbol.length - 5, currency.symbol.length)
-                    : currency?.symbol) || t('selectToken')}
+                    : currency?.symbol) || t('Select Token')}
                 </StyledTokenName>
               )}
               {!disableCurrencySelect && <StyledDropDown selected={!!currency} />}

--- a/src/components/CurrencyInputPanel/index.tsx
+++ b/src/components/CurrencyInputPanel/index.tsx
@@ -198,6 +198,7 @@ interface CurrencyInputPanelProps {
   hideBalance?: boolean
   pair?: Pair | null
   hideInput?: boolean
+  disabledInput?: boolean
   otherCurrency?: Token | null
   id: string
   showCommonBases?: boolean
@@ -217,6 +218,7 @@ export default function CurrencyInputPanel({
   hideBalance = false,
   pair = null, // used for double token logo
   hideInput = false,
+  disabledInput = false,
   otherCurrency,
   id,
   showCommonBases,
@@ -286,6 +288,7 @@ export default function CurrencyInputPanel({
               <NumericalInput
                 className="token-amount-input"
                 value={value}
+                disabled={disabledInput}
                 onUserInput={(val) => {
                   onUserInput(val)
                 }}

--- a/src/components/NumericalInput/index.tsx
+++ b/src/components/NumericalInput/index.tsx
@@ -3,7 +3,13 @@ import styled from 'styled-components'
 
 import { escapeRegExp } from '../../utils'
 
-const StyledInput = styled.input<{ error?: boolean; white?: boolean; fontSize?: string; align?: string }>`
+const StyledInput = styled.input<{
+  error?: boolean
+  white?: boolean
+  fontSize?: string
+  align?: string
+  disabled?: boolean
+}>`
   color: ${({ error, theme }) => (error ? theme.red1 : theme.text1)};
   width: 0;
   position: relative;
@@ -16,6 +22,7 @@ const StyledInput = styled.input<{ error?: boolean; white?: boolean; fontSize?: 
   background-color: rgba(0, 0, 0, 0);
   font-size: ${({ fontSize }) => fontSize ?? '24px'};
   text-align: ${({ align }) => align && align};
+  cursor: ${({ disabled }) => disabled && 'not-allowed'};
   white-space: nowrap;
   overflow: hidden;
   padding: 0px;
@@ -45,12 +52,14 @@ export const Input = React.memo(function InnerInput({
   value,
   onUserInput,
   placeholder,
+  disabled,
   ...rest
 }: {
   value: string | number
   onUserInput: (input: string) => void
   error?: boolean
   fontSize?: string
+  disabled?: boolean
   align?: 'right' | 'left'
 } & Omit<React.HTMLProps<HTMLInputElement>, 'ref' | 'onChange' | 'as'>) {
   const enforcer = (nextUserInput: string) => {
@@ -72,6 +81,7 @@ export const Input = React.memo(function InnerInput({
       title="Token Amount"
       autoComplete="off"
       autoCorrect="off"
+      disabled={disabled}
       // text-specific options
       type="text"
       pattern="^[0-9]*[.,]?[0-9]*$"

--- a/src/components/swap/styleds.tsx
+++ b/src/components/swap/styleds.tsx
@@ -51,7 +51,7 @@ export const SectionBreak = styled.div`
 `
 
 export const BottomGrouping = styled.div`
-  margin-top: 0rem;
+  padding-top: 0.15rem;
 `
 
 export const ErrorText = styled(Text)<{ severity?: 0 | 1 | 2 | 3 | 4 }>`

--- a/src/components/swap/styleds.tsx
+++ b/src/components/swap/styleds.tsx
@@ -51,7 +51,7 @@ export const SectionBreak = styled.div`
 `
 
 export const BottomGrouping = styled.div`
-  margin-top: 1rem;
+  margin-top: 0rem;
 `
 
 export const ErrorText = styled(Text)<{ severity?: 0 | 1 | 2 | 3 | 4 }>`

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -264,6 +264,7 @@ export default function Swap() {
                 value={formattedAmounts[Field.OUTPUT]}
                 onUserInput={handleTypeOutput}
                 label={independentField === Field.INPUT && trade ? `To${isEstimate ? ' (estimated)' : ''}` : 'To'}
+                disabledInput={true}
                 showMaxButton={false}
                 currency={currencies[Field.OUTPUT]}
                 onCurrencySelect={handleOutputSelect}

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -287,8 +287,12 @@ export default function Swap() {
                       />
                     </RowBetween>
                     <RowBetween>
-                      <TYPE.body>Price Impact</TYPE.body>
-                      <TYPE.body>{`${trade?.priceImpact.toFixed(4)}%`}</TYPE.body>
+                      <Text fontWeight={500} fontSize={14} color={theme.text2}>
+                        Price Impact
+                      </Text>
+                      <Text fontWeight={500} fontSize={14} color={theme.text2}>
+                        {`${trade?.priceImpact.toFixed(4)}%`}
+                      </Text>
                     </RowBetween>
                   </>
                 )}


### PR DESCRIPTION
![Screen Shot 2022-01-26 at 10 46 27 AM](https://user-images.githubusercontent.com/43524469/151196657-740c67b8-872b-4841-babf-c972a46108d4.png)

- Fixed name of 'Select Token'
- Removed to and from labels
- moved balance to bottom
- fixed gap between input card and swap button



