### PR TITLE
Swap style fix

### DIFF
--- a/src/components/CurrencyInputPanel/index.tsx
+++ b/src/components/CurrencyInputPanel/index.tsx
@@ -295,7 +295,7 @@ export default function CurrencyInputPanel({
                     ? currency.symbol.slice(0, 4) +
                       '...' +
                       currency.symbol.slice(currency.symbol.length - 5, currency.symbol.length)
-                    : currency?.symbol) || t('selectToken')}
+                    : currency?.symbol) || t('Select Token')}
                 </StyledTokenName>
               )}
               {!disableCurrencySelect && <StyledDropDown selected={!!currency} />}

--- a/src/components/CurrencyInputPanel/index.tsx
+++ b/src/components/CurrencyInputPanel/index.tsx
@@ -198,6 +198,7 @@ interface CurrencyInputPanelProps {
   hideBalance?: boolean
   pair?: Pair | null
   hideInput?: boolean
+  disableInput?: boolean
   otherCurrency?: Token | null
   id: string
   showCommonBases?: boolean
@@ -215,6 +216,7 @@ export default function CurrencyInputPanel({
   currency,
   disableCurrencySelect = false,
   hideBalance = false,
+  disableInput = false,
   pair = null, // used for double token logo
   hideInput = false,
   otherCurrency,
@@ -308,6 +310,7 @@ export default function CurrencyInputPanel({
               <NumericalInput
                 className="token-amount-input"
                 value={value}
+                disabled={disableInput}
                 onUserInput={(val) => {
                   onUserInput(val)
                 }}

--- a/src/components/NumericalInput/index.tsx
+++ b/src/components/NumericalInput/index.tsx
@@ -3,7 +3,13 @@ import styled from 'styled-components'
 
 import { escapeRegExp } from '../../utils'
 
-const StyledInput = styled.input<{ error?: boolean; white?: boolean; fontSize?: string; align?: string }>`
+const StyledInput = styled.input<{
+  error?: boolean
+  white?: boolean
+  fontSize?: string
+  align?: string
+  disabled?: boolean
+}>`
   color: ${({ error, theme }) => (error ? theme.red1 : theme.text1)};
   width: 0;
   position: relative;
@@ -19,6 +25,7 @@ const StyledInput = styled.input<{ error?: boolean; white?: boolean; fontSize?: 
   white-space: nowrap;
   overflow: hidden;
   padding: 0px;
+  cursor: ${({ disabled }) => disabled && 'not-allowed'};
   -webkit-appearance: textfield;
 
   ::-webkit-search-decoration {
@@ -45,11 +52,13 @@ export const Input = React.memo(function InnerInput({
   value,
   onUserInput,
   placeholder,
+  disabled,
   ...rest
 }: {
   value: string | number
   onUserInput: (input: string) => void
   error?: boolean
+  disabled?: boolean
   fontSize?: string
   align?: 'right' | 'left'
 } & Omit<React.HTMLProps<HTMLInputElement>, 'ref' | 'onChange' | 'as'>) {
@@ -74,6 +83,7 @@ export const Input = React.memo(function InnerInput({
       autoCorrect="off"
       // text-specific options
       type="text"
+      disabled={disabled}
       pattern="^[0-9]*[.,]?[0-9]*$"
       placeholder={placeholder || '0.0'}
       minLength={1}

--- a/src/components/swap/styleds.tsx
+++ b/src/components/swap/styleds.tsx
@@ -51,7 +51,7 @@ export const SectionBreak = styled.div`
 `
 
 export const BottomGrouping = styled.div`
-  margin-top: 1rem;
+  padding-top: 0.25rem;
 `
 
 export const ErrorText = styled(Text)<{ severity?: 0 | 1 | 2 | 3 | 4 }>`

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -288,8 +288,12 @@ export default function Swap() {
                       />
                     </RowBetween>
                     <RowBetween>
-                      <TYPE.body>Price Impact</TYPE.body>
-                      <TYPE.body>{`${trade?.priceImpact.toFixed(4)}%`}</TYPE.body>
+                      <Text fontWeight={500} fontSize={14} color={theme.text2}>
+                        PriceImpact
+                      </Text>
+                      <Text fontWeight={500} fontSize={14} color={theme.text2}>
+                        {`${trade?.priceImpact.toFixed(4)}%`}
+                      </Text>
                     </RowBetween>
                   </>
                 )}

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -266,6 +266,7 @@ export default function Swap() {
                 label={independentField === Field.INPUT && trade ? `To${isEstimate ? ' (estimated)' : ''}` : 'To'}
                 showMaxButton={false}
                 currency={currencies[Field.OUTPUT]}
+                disableInput={true}
                 onCurrencySelect={handleOutputSelect}
                 otherCurrency={currencies[Field.INPUT]}
                 id="swap-currency-output"


### PR DESCRIPTION
<img width="435" alt="Screen Shot 2022-01-26 at 6 07 39 PM" src="https://user-images.githubusercontent.com/43524469/151262240-754dd3bb-31ca-4827-a030-b605c7e5407e.png">

- font fix for `price impact`
- gap between bottom of swap modal and button
- renamed selectToken to Select Token
- disable input on `to` input component