### PR TITLE
Add cREAL to Mento

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
   "dependencies": {
     "@apollo/client": "^3.4.16",
     "@celo/connect": "^1.2.0",
-    "@celo/contractkit": "^1.2.0",
+    "@celo/contractkit": "1.5.1",
     "@celo/utils": "^1.2.1",
     "@celo/wallet-ledger": "^1.2.0",
     "@craco/craco": "^6.1.2",

--- a/src/constants/StablePools.ts
+++ b/src/constants/StablePools.ts
@@ -1283,6 +1283,33 @@ export const MENTO_POOL_INFO: { [K in ChainId]: MentoConstants[] } = {
         ),
       ],
     },
+    {
+      stable: StableToken.cREAL,
+      tokens: [
+        new WrappedTokenInfo(
+          {
+            chainId: ChainId.MAINNET,
+            address: '0x471EcE3750Da237f93B8E339c536989b8978a438',
+            decimals: 18,
+            symbol: 'CELO',
+            name: 'Celo native asset',
+            logoURI: 'https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_CELO.png',
+          },
+          []
+        ),
+        new WrappedTokenInfo(
+          {
+            chainId: ChainId.MAINNET,
+            address: '0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787',
+            decimals: 18,
+            symbol: 'cREAL',
+            name: 'Celo Brazilian Real',
+            logoURI: 'https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cREAL.png',
+          },
+          []
+        ),
+      ],
+    },
   ],
   [ChainId.ALFAJORES]: [],
   [ChainId.BAKLAVA]: [],

--- a/src/constants/StablePools.ts
+++ b/src/constants/StablePools.ts
@@ -95,12 +95,6 @@ export const PRICE: { [c in Coins]: number } = {
   [Coins.Eur]: 1.17,
 }
 
-export const MOBIUS_STRIP_ADDRESS: { [K in ChainId]: string } = {
-  [ChainId.MAINNET]: '',
-  [ChainId.ALFAJORES]: '0x20707684E796c7cb04CBB1a3bDB6AB40A02f2D12',
-  [ChainId.BAKLAVA]: '',
-}
-
 export const MOBIUS_MINTER_ADDRESS: { [K in ChainId]: string } = {
   [ChainId.MAINNET]: '0x5F0200CA03196D5b817E2044a0Bb0D837e0A7823',
   [ChainId.ALFAJORES]: '0x5c212FA1cf8b1143f2142C26161e65404034c01f',

--- a/src/pages/Mento/index.tsx
+++ b/src/pages/Mento/index.tsx
@@ -227,7 +227,7 @@ export default function Mento() {
               <RowBetween>
                 <TYPE.white
                   fontSize={14}
-                >{`Mint cUSD and cEUR by depositing CELO to the Celo Reserve. This exchange includes a 0.25% fee that is collected by the Celo Reserve.`}</TYPE.white>
+                >{`Mint cUSD, cEUR, and cREAL by depositing CELO to the Celo Reserve. This exchange includes a 0.25% fee that is collected by the Celo Reserve.`}</TYPE.white>
               </RowBetween>
               <ExternalLink
                 style={{ color: 'white', textDecoration: 'underline' }}

--- a/src/state/mentoPools/updater.ts
+++ b/src/state/mentoPools/updater.ts
@@ -49,8 +49,10 @@ export function UpdateMento(): null {
       let address: string
       if (pool.stable === StableToken.cUSD) {
         address = await kit.registry.addressFor(CeloContract.Exchange)
-      } else {
+      } else if (pool.stable === StableToken.cEUR) {
         address = await kit.registry.addressFor(CeloContract.ExchangeEUR)
+      } else {
+        address = await kit.registry.addressFor(CeloContract.ExchangeBRL)
       }
       updatePool(pool, mentoContract?.attach(address))
     })


### PR DESCRIPTION
Bumps contractkit to the newest version that includes cREAL and then adds cREAL as a mento type. Closes #134 