### PR TITLE
Hotfix: Pull amp coeff straight from contract

### DIFF
--- a/src/state/stablePools/hooks.ts
+++ b/src/state/stablePools/hooks.ts
@@ -10,6 +10,7 @@ import { useEthBtcPrice } from 'state/application/hooks'
 import { useDefaultTokenList, WrappedTokenInfo } from 'state/lists/hooks'
 import { useSingleContractMultipleData } from 'state/multicall/hooks'
 import { tryParseAmount } from 'state/swap/hooks'
+import { PairStableSwap } from 'utils/StablePairMath'
 
 import WARNINGS from '../../constants/PoolWarnings.json'
 import { StableSwapMath } from '../../utils/stableSwapMath'
@@ -284,4 +285,9 @@ export function useWarning(
   )
   if (!warningType) return undefined
   return WARNINGS[warningType] as any as { warning: string; link?: string; modification?: WarningModifications }
+}
+
+export function usePairUtil(pool: StableSwapPool | string): PairStableSwap | undefined {
+  const name = !pool ? '' : typeof pool == 'string' ? pool : pool.address
+  return useSelector<AppState, PairStableSwap | undefined>((state) => state.stablePools.pools[name.toLowerCase()]?.pair)
 }

--- a/src/state/stablePools/hooks.ts
+++ b/src/state/stablePools/hooks.ts
@@ -287,7 +287,7 @@ export function useWarning(
   return WARNINGS[warningType] as any as { warning: string; link?: string; modification?: WarningModifications }
 }
 
-export function usePairUtil(pool: StableSwapPool | string): PairStableSwap | undefined {
+export function usePairUtil(pool?: StableSwapPool | string): PairStableSwap | undefined {
   const name = !pool ? '' : typeof pool == 'string' ? pool : pool.address
   return useSelector<AppState, PairStableSwap | undefined>((state) => state.stablePools.pools[name.toLowerCase()]?.pair)
 }

--- a/src/state/stablePools/reducer.ts
+++ b/src/state/stablePools/reducer.ts
@@ -3,6 +3,7 @@ import { Fraction, Percent, Token } from '@ubeswap/sdk'
 import { NETWORK_CHAIN_ID } from 'connectors'
 import { Chain, Coins, STATIC_POOL_INFO } from 'constants/StablePools'
 import JSBI from 'jsbi'
+import { PairStableSwap } from 'utils/StablePairMath'
 import { StableSwapMath } from 'utils/stableSwapMath'
 
 import { updateExternalRewards, updateGauges, updatePools } from './actions'
@@ -94,6 +95,7 @@ export interface PoolState {
     [address: string]: {
       pool: StableSwapPool | StableSwapConstants
       math: StableSwapMath | undefined
+      pair?: PairStableSwap | undefined
     }
   }
 }
@@ -151,11 +153,20 @@ export default createReducer<PoolState>(initialState, (builder) =>
       info.forEach((pool) => {
         const cur = copiedState.pools[pool.id].pool as any as StableSwapPool
         const newPool = { ...cur, ...pool }
+        const { balances, aPrecise, swapFee, tokens } = newPool
 
         const math = new StableSwapMath(newPool)
+        const pair = new PairStableSwap(
+          balances.map((el) => el.toString()),
+          swapFee.toString(),
+          aPrecise.toString(),
+          tokens.map((t) => t.decimals)
+        )
+
         state.pools[pool.id] = {
           pool: newPool,
           math,
+          pair,
         }
       })
     })

--- a/src/state/stablePools/reducer.ts
+++ b/src/state/stablePools/reducer.ts
@@ -154,14 +154,21 @@ export default createReducer<PoolState>(initialState, (builder) =>
         const cur = copiedState.pools[pool.id].pool as any as StableSwapPool
         const newPool = { ...cur, ...pool }
         const { balances, aPrecise, swapFee, tokens } = newPool
-
+        // console.log(
+        //   balances?.map((el) => el.toString()) ?? ['0', '0'],
+        //   swapFee?.toString() ?? '0',
+        //   aPrecise?.toString() ?? '0'
+        // )
         const math = new StableSwapMath(newPool)
-        const pair = new PairStableSwap(
-          balances.map((el) => el.toString()),
-          swapFee.toString(),
-          aPrecise.toString(),
-          tokens.map((t) => t.decimals)
-        )
+        const pair =
+          balances && aPrecise && swapFee
+            ? new PairStableSwap(
+                balances?.map((el) => el.toString()) ?? ['0', '0'],
+                swapFee?.toString() ?? '0',
+                aPrecise?.toString() ?? '0',
+                tokens.map((t) => t.decimals)
+              )
+            : undefined
 
         state.pools[pool.id] = {
           pool: newPool,

--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -307,17 +307,10 @@ function calcInputOutput(
     undefined,
   ]
 
-  if (isExactIn) {
-    details[0] = parsedAmount
-    const [expectedOut, fee] = math.outputAmount(indexFrom, indexTo, parsedAmount.raw)
-    details[1] = new TokenAmount(output, expectedOut)
-    details[2] = new TokenAmount(input, fee)
-  } else {
-    details[1] = parsedAmount
-    const requiredIn = math.get_dx(indexFrom, indexTo, parsedAmount.raw, math.calc_xp())
-    details[0] = new TokenAmount(input, requiredIn)
-    details[2] = new TokenAmount(input, JSBI.BigInt('0'))
-  }
+  details[0] = parsedAmount
+  const [expectedOut, fee] = math.outputAmount(indexFrom, indexTo, parsedAmount.raw)
+  details[1] = new TokenAmount(output, expectedOut)
+  details[2] = new TokenAmount(input, fee)
   return details
 }
 

--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -287,7 +287,7 @@ function calcInputOutput(
   underlyingMath?: StableSwapMath,
   underlyingPool?: StableSwapPool
 ): readonly [TokenAmount | undefined, TokenAmount | undefined, TokenAmount | undefined] {
-  if (!input && !output) {
+  if ((!input && !output) || !parsedAmount) {
     return [undefined, undefined, undefined]
   }
   const { tokens } = poolInfo

--- a/src/utils/StablePairMath.ts
+++ b/src/utils/StablePairMath.ts
@@ -48,8 +48,9 @@ export class PairStableSwap {
     return d1.minus(d0).multipliedBy(this.lpTotalSupply).dividedBy(d0)
   }
 
-  public outputAmount(tokenIndexFrom: number, tokenIndexTo: number, inputAmount: BigNumber): [JSBI, JSBI] {
+  public outputAmount(tokenIndexFrom: number, tokenIndexTo: number, input: JSBI): [JSBI, JSBI] {
     // See: https://github.com/mobiusAMM/mobiusV1/blob/master/contracts/SwapUtils.sol#L617
+    const inputAmount = new BigNumber(input.toString())
     const x = inputAmount
       .multipliedBy(this.tokenPrecisionMultipliers[tokenIndexFrom])
       .plus(this.balancesWithAdjustedPrecision[tokenIndexFrom])

--- a/src/utils/StablePairMath.ts
+++ b/src/utils/StablePairMath.ts
@@ -1,0 +1,129 @@
+import { JSBI } from '@ubeswap/sdk'
+import BigNumber from 'bignumber.js'
+
+// See https://github.com/d-mooers/swappa/blob/main/src/pairs/stableswap.ts
+
+type Address = string
+export class PairStableSwap {
+  allowRepeats = false
+
+  private paused = false
+  private tokenPrecisionMultipliers: BigNumber[] = []
+  private balancesWithAdjustedPrecision: BigNumber[] = []
+  private balances: BigNumber[] = []
+  private swapFee: BigNumber = new BigNumber(0)
+  private preciseA: BigNumber = new BigNumber(0)
+  private lpTotalSupply: BigNumber = new BigNumber(0)
+
+  static readonly POOL_PRECISION_DECIMALS = 18
+  static readonly A_PRECISION = 100
+
+  constructor(balances: string[], swapFee: string, preciseA: string, decimals: number[]) {
+    const [decimalsA, decimalsB] = decimals
+    this.tokenPrecisionMultipliers = [
+      new BigNumber(10).pow(PairStableSwap.POOL_PRECISION_DECIMALS - decimalsA),
+      new BigNumber(10).pow(PairStableSwap.POOL_PRECISION_DECIMALS - decimalsB),
+    ]
+    this.balances = balances.map((n) => new BigNumber(n))
+    this.balancesWithAdjustedPrecision = balances.map((b, idx) => this.tokenPrecisionMultipliers[idx].multipliedBy(b))
+    this.swapFee = new BigNumber(swapFee).div(new BigNumber(10).pow(10))
+    this.preciseA = new BigNumber(preciseA)
+  }
+
+  public deposit(
+    tokenA: Address,
+    inputA: BigNumber,
+    tokenB: Address,
+    inputB: BigNumber,
+    isDeposit: boolean
+  ): BigNumber {
+    const amounts = tokenA === this.tokenA ? [inputA, inputB] : [inputB, inputA]
+    const d0 = this.getD(this.balancesWithAdjustedPrecision, this.preciseA)
+    const balances = this.balances.map((b, i) => (isDeposit ? b.plus(amounts[i]) : b.minus(amounts[i])))
+    const d1 = this.getD(
+      balances.map((b, idx) => this.tokenPrecisionMultipliers[idx].multipliedBy(b)),
+      this.preciseA
+    )
+
+    return d1.minus(d0).multipliedBy(this.lpTotalSupply).dividedBy(d0)
+  }
+
+  public outputAmount(tokenIndexFrom: number, tokenIndexTo: number, inputAmount: BigNumber): [JSBI, JSBI] {
+    // See: https://github.com/mobiusAMM/mobiusV1/blob/master/contracts/SwapUtils.sol#L617
+    const x = inputAmount
+      .multipliedBy(this.tokenPrecisionMultipliers[tokenIndexFrom])
+      .plus(this.balancesWithAdjustedPrecision[tokenIndexFrom])
+    const y = this.getY(x, this.balancesWithAdjustedPrecision, this.preciseA)
+    const outputAmountWithFee = this.balancesWithAdjustedPrecision[tokenIndexTo].minus(y).minus(1)
+    const fee = outputAmountWithFee.multipliedBy(this.swapFee)
+    const outputAmount = outputAmountWithFee.minus(fee).div(this.tokenPrecisionMultipliers[tokenIndexTo]).integerValue()
+    return [JSBI.BigInt(outputAmount.toFixed(0)), JSBI.BigInt(fee.toFixed(0))]
+  }
+
+  private getY = (x: BigNumber, xp: BigNumber[], a: BigNumber) => {
+    // See: https://github.com/mobiusAMM/mobiusV1/blob/master/contracts/SwapUtils.sol#L531
+    const d = this.getD(xp, a)
+    const nTokens = xp.length
+    const nA = a.multipliedBy(nTokens)
+
+    const s = x
+    const c = d
+      .multipliedBy(d)
+      .div(x.multipliedBy(nTokens))
+      .integerValue()
+      .multipliedBy(d)
+      .multipliedBy(PairStableSwap.A_PRECISION)
+      .div(nA.multipliedBy(nTokens))
+      .integerValue()
+    const b = s.plus(d.multipliedBy(PairStableSwap.A_PRECISION).div(nA)).integerValue()
+
+    let yPrev
+    let y = d
+    for (let i = 0; i < 256; i++) {
+      yPrev = y
+      y = y.multipliedBy(y).plus(c).div(y.multipliedBy(2).plus(b).minus(d)).integerValue()
+      if (y.minus(yPrev).abs().lte(1)) {
+        return y
+      }
+    }
+    throw new Error('SwapPool approximation did not converge!')
+  }
+
+  private getD(xp: BigNumber[], a: BigNumber) {
+    // See: https://github.com/mobiusAMM/mobiusV1/blob/master/contracts/SwapUtils.sol#L393
+    const s = BigNumber.sum(...xp)
+    if (s.eq(0)) {
+      return s
+    }
+
+    let prevD
+    let d = s
+    const nTokens = xp.length
+    const nA = a.multipliedBy(nTokens)
+
+    for (let i = 0; i < 256; i++) {
+      let dP = d
+      xp.forEach((x) => {
+        dP = dP.multipliedBy(d).div(x.multipliedBy(nTokens)).integerValue()
+      })
+      prevD = d
+      d = nA
+        .multipliedBy(s)
+        .div(PairStableSwap.A_PRECISION)
+        .plus(dP.multipliedBy(nTokens))
+        .multipliedBy(d)
+        .div(
+          nA
+            .minus(PairStableSwap.A_PRECISION)
+            .multipliedBy(d)
+            .div(PairStableSwap.A_PRECISION)
+            .plus(new BigNumber(nTokens).plus(1).multipliedBy(dP))
+        )
+        .integerValue()
+      if (d.minus(prevD).abs().lte(1)) {
+        return d
+      }
+    }
+    throw new Error('SwapPool D does not converge!')
+  }
+}


### PR DESCRIPTION
Previously we pulled from the subgraph but there is now a discrepancy between subgraph's amp coefficient and the contract.  The subgraph is incorrect.

Also fixed some math util issues