### PR TITLE
Hotfix - Lock Mobi Bug

### DIFF
--- a/src/pages/Staking/Stake.tsx
+++ b/src/pages/Staking/Stake.tsx
@@ -106,7 +106,7 @@ export default function Stake({ stakingInfo }: PropTypes) {
               gap: '1rem',
             }}
           >
-            {Date.now() > (lockEnd?.valueOf() ?? 0) ? (
+            {Date.now() > (lockEnd?.valueOf() ?? 0) && mobiLocked && mobiLocked.greaterThan('0') ? (
               <ButtonPrimary
                 onClick={onClaim}
                 style={{ fontWeight: 700, fontSize: 18, backgroundColor: theme(false).celoRed }}


### PR DESCRIPTION
The logic to display the "Claim" button was only based off of the lock end date, which will be 0 if a user has no lock. This caused the "Claim" button to show instead of "Deposit" for new users looking to lock their MOBI.