### PR TITLE
Hotfix: ledger index on pages >1

### DIFF
--- a/src/components/WalletModal/LedgerWalletSelector/index.tsx
+++ b/src/components/WalletModal/LedgerWalletSelector/index.tsx
@@ -69,7 +69,11 @@ export const LedgerWalletSelector: React.FC<Props> = ({ handleSelectIndex }: Pro
           ) : (
             <OptionsGrid>
               {addresses.map((address, i) => (
-                <LedgerAddress key={address} address={address} tryActivation={() => handleSelectIndex(i)} />
+                <LedgerAddress
+                  key={address}
+                  address={address}
+                  tryActivation={() => handleSelectIndex(page * ADDRESSES_PER_PAGE + i)}
+                />
               ))}
               <InfoCard
                 onClick={() => {


### PR DESCRIPTION
A user pointed out this bug in the Discord. When you are connected to a ledger on not the first page, it selects like you are selecting on the first page