### PR TITLE
Fix APR Calculations across the board

### DIFF
--- a/src/Context/SwappaContext.tsx
+++ b/src/Context/SwappaContext.tsx
@@ -2,7 +2,6 @@ import { ContractKit, newKitFromWeb3 } from '@celo/contractkit'
 import * as Swappa from '@mobius-money/swappa'
 import { mainnetRegistryMobius, mainnetRegistryMoolaV2, mainnetRegistryUbeswap } from '@mobius-money/swappa'
 import { CHAIN_INFO, ChainId } from '@ubeswap/sdk'
-import { STATIC_POOL_INFO } from 'constants/StablePools'
 import { getAllTokens } from 'hooks/Tokens'
 import * as React from 'react'
 import Web3 from 'web3'
@@ -22,17 +21,6 @@ async function initializeSwappa(): Promise<Swappa.SwappaManager | undefined> {
   const web3 = new Web3(CHAIN_INFO[ChainId.MAINNET].fornoURL)
   const kit = newKitFromWeb3(web3)
   const registries = genRegistries(kit)
-  console.log(STATIC_POOL_INFO[ChainId.MAINNET].map(({ address }) => address))
-  // const mobiusRegistry = new Swappa.RegistryStatic(
-  //   'mobius',
-  //   new Promise((resolve) =>
-  //     resolve(
-  //       STATIC_POOL_INFO[ChainId.MAINNET].map(({ address }) => {
-  //         return new Swappa.PairStableSwap(ChainId.MAINNET, web3, address)
-  //       })
-  //     )
-  //   )
-  // )
   try {
     const supportedTokens = getAllTokens()
     const swappa = new Swappa.SwappaManager(kit, Swappa.swappaRouterV1Address, registries)

--- a/src/components/earn/StablePoolCard.tsx
+++ b/src/components/earn/StablePoolCard.tsx
@@ -1,9 +1,8 @@
-import { cUSD, Fraction, JSBI, Percent, Price, TokenAmount } from '@ubeswap/sdk'
+import { Fraction, JSBI, Percent, TokenAmount } from '@ubeswap/sdk'
 import Loader from 'components/Loader'
 import QuestionHelper from 'components/QuestionHelper'
 import { ChainLogo, Coins } from 'constants/StablePools'
 import { useWeb3Context } from 'hooks'
-import { useMobi } from 'hooks/Tokens'
 import { darken } from 'polished'
 import React, { useState } from 'react'
 import { isMobile } from 'react-device-detect'
@@ -11,12 +10,10 @@ import { useHistory } from 'react-router'
 import { NavLink } from 'react-router-dom'
 import styled from 'styled-components'
 import { getDepositValues } from 'utils/stableSwaps'
-import { getCUSDPrices, useCUSDPrice } from 'utils/useCUSDPrice'
 
-import { BIG_INT_SECONDS_IN_WEEK, BIG_INT_SECONDS_IN_YEAR, CHAIN } from '../../constants'
+import { BIG_INT_SECONDS_IN_WEEK } from '../../constants'
 import { useColor, usePoolColor } from '../../hooks/useColor'
-import { useTokenPrices } from '../../state/application/hooks'
-import { StablePoolInfo } from '../../state/stablePools/hooks'
+import { StablePoolInfo, useAPR } from '../../state/stablePools/hooks'
 import { theme, TYPE } from '../../theme'
 import { ButtonPrimary } from '../Button'
 import { AutoColumn } from '../Column'
@@ -168,9 +165,7 @@ export const StablePoolCard: React.FC<Props> = ({ poolInfo }: Props) => {
     balances,
     totalDeposited,
     stakedAmount,
-    workingSupply,
     pegComesAfter,
-    feesGenerated,
     mobiRate,
     displayDecimals,
     totalStakedAmount: totalStakedLPs,
@@ -180,47 +175,11 @@ export const StablePoolCard: React.FC<Props> = ({ poolInfo }: Props) => {
   const [openDeposit, setOpenDeposit] = useState(false)
   const [openWithdraw, setOpenWithdraw] = useState(false)
   const [openManage, setOpenManage] = useState(false)
-  const tokenPrices = getCUSDPrices(useTokenPrices())
   const history = useHistory()
 
-  const mobi = useMobi()
-  const priceOfMobi = useCUSDPrice(mobi) ?? new Price(mobi, cUSD[CHAIN], '100', '1')
   const userLP = poolInfo.amountDeposited
-  const { totalValueDeposited, valueOfDeposited } = getDepositValues(poolInfo, workingSupply)
-  const coinPrice = tokens.reduce(
-    (accum: Fraction | undefined, { address }) => accum ?? tokenPrices[address.toLowerCase()],
-    undefined
-  )
-
-  const totalStakedAmount = totalValueDeposited
-    ? totalValueDeposited.multiply(new Fraction(coinPrice?.numerator ?? '1', coinPrice?.denominator ?? '1'))
-    : new Fraction(JSBI.BigInt(0))
-  const totalMobiRate = new TokenAmount(mobi, mobiRate ?? JSBI.BigInt('0'))
-
-  const rewardPerYear = priceOfMobi.raw.multiply(totalMobiRate.multiply(BIG_INT_SECONDS_IN_YEAR))
-  let rewardPerYearExternal = new Fraction('0', '1')
-  for (let i = 0; i < 8; i++) {
-    const rate = poolInfo.externalRewardRates?.[i] ?? totalMobiRate
-    const priceOfToken =
-      tokenPrices[rate.token.address.toLowerCase()] ?? tokenPrices['0x00be915b9dcf56a3cbe739d9b9c202ca692409ec']
-    if (poolInfo.externalRewardRates && i < poolInfo.externalRewardRates.length) {
-      rewardPerYearExternal = rewardPerYearExternal.add(
-        priceOfToken?.multiply(rate.multiply(BIG_INT_SECONDS_IN_YEAR)) ?? '0'
-      )
-    }
-  }
-  const [apyFraction, apy, dpy] =
-    mobiRate && totalStakedAmount && !totalStakedAmount.equalTo(JSBI.BigInt(0))
-      ? calcApy(rewardPerYear.add(rewardPerYearExternal), totalStakedAmount)
-      : [undefined, undefined, undefined]
-
-  const [boostedApyFraction, boostedApy, boostedDpy] =
-    mobiRate && totalStakedAmount && !totalStakedAmount.equalTo(JSBI.BigInt(0))
-      ? calcApy(
-          rewardPerYear.multiply(new Fraction(JSBI.BigInt(5), JSBI.BigInt(2))).add(rewardPerYearExternal),
-          totalStakedAmount
-        )
-      : [new Fraction('0', '1'), new Fraction('0', '1'), new Fraction('0', '1')]
+  const { totalValueDeposited, valueOfDeposited } = getDepositValues(poolInfo)
+  const { base: apy, baseDpy: dpy, boosted: boostedApy } = useAPR(poolInfo.poolAddress)
 
   let weeklyAPY: React.ReactNode | undefined = <>🤯</>
   try {

--- a/src/state/stablePools/hooks.ts
+++ b/src/state/stablePools/hooks.ts
@@ -357,5 +357,5 @@ export function useAPR(poolName?: string): {
       boosted: boostedApy ?? new Fraction('0'),
       boostedDpy: boostedDpy ?? new Fraction('0'),
     }
-  }, [pool])
+  }, [pool, tokenPrices])
 }


### PR DESCRIPTION
APRs previously naively assumed that each deposit will initially receive an equal allocation of mobi rewards.  

However, in cases where a large number of people are staking mobi, this is not the case.  The two bounds are as follows:

Let W be working liquidity for a pool
Let L be total liquidity for a pool
Define b = W / L

If b = 0.4, then nobody in the pool is boosting, so the effective mobi rate for base APR is the actual mobi emissions
If b = 1, then everybody in the pool is at max boost (not sure this is even possible, but its a boundary), at which case the mobi emissions for calculating base APR need to be 0.4 * emission.

Thus, if k is the base emission rate and k\` is the adjusted, k\` is very easily calculated as
k`(b) = k - (0.4 - b)k = 1.4k - bk